### PR TITLE
Call admin API before joining a BBB room to get fresh credentials

### DIFF
--- a/back/src/Model/GameRoom.ts
+++ b/back/src/Model/GameRoom.ts
@@ -768,6 +768,32 @@ export class GameRoom implements BrothersFinder {
         throw new Error("Unexpected room redirect received or error while querying map details");
     }
 
+    /**
+     * Connects to the admin server to fetch map details with user context.
+     * This version passes user information to the admin API to get user-specific settings.
+     */
+    private static async getMapDetailsWithUser(roomUrl: string, user: User): Promise<MapDetailsData> {
+        if (!ADMIN_API_URL) {
+            // Fall back to the regular method if no admin API
+            return GameRoom.getMapDetails(roomUrl);
+        }
+
+        const userId = user.uuid;
+        const result = isMapDetailsData.safeParse(await adminApi.fetchMapDetails(roomUrl, userId));
+
+        if (result.success) {
+            return result.data;
+        }
+
+        console.error(result.error.issues);
+        console.error("Unexpected room redirect or error received while querying map details with user", result);
+        Sentry.captureException(result.error.issues);
+        Sentry.captureException(
+            `Unexpected room redirect or error received while querying map details with user ${JSON.stringify(result)}`
+        );
+        throw new Error("Unexpected room redirect received or error while querying map details with user");
+    }
+
     private mapPromise: Promise<ITiledMap> | undefined;
 
     /**
@@ -1050,17 +1076,47 @@ export class GameRoom implements BrothersFinder {
         return undefined;
     }
 
-    public getBbbSettings(): MapBbbData | undefined {
+    public async getBbbSettings(user?: User): Promise<MapBbbData | undefined> {
+        // If we have a user, try to get fresh settings from admin API
+        if (user && ADMIN_API_URL) {
+            try {
+                console.log(`Attempting to fetch fresh BBB settings for user: ${user.name} (${user.uuid})`);
+                const mapDetails = await GameRoom.getMapDetailsWithUser(this._roomUrl, user);
+                if (mapDetails.thirdParty?.bbb) {
+                    console.log(`Using fresh BBB settings from Admin API for user: `, {
+                        url: mapDetails.thirdParty.bbb.url,
+                        secret: "[REDACTED]",
+                    });
+                    return mapDetails.thirdParty.bbb;
+                }
+            } catch (e) {
+                console.warn("Failed to fetch fresh BBB settings, falling back to stored settings", e);
+            }
+        }
+
+        // Fall back to stored settings
         const bbb = this.thirdParty?.bbb;
         if (bbb) {
+            console.log(`Using stored BBB settings from Admin API: `, {
+                url: bbb.url,
+                secret: "[REDACTED]",
+            });
             return bbb;
         }
+
+        // Environment variable fallback
         if (BBB_URL && BBB_SECRET) {
+            console.log(`Using BBB settings from environment variables: `, {
+                url: BBB_URL,
+                secret: "[REDACTED]",
+            });
             return {
                 url: BBB_URL,
                 secret: BBB_SECRET,
             };
         }
+
+        console.log(`No BBB settings available`);
         return undefined;
     }
 

--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -11,14 +11,26 @@ import * as Sentry from "@sentry/node";
 import { ADMIN_API_TOKEN, ADMIN_API_URL } from "../Enum/EnvironmentVariable";
 
 class AdminApi {
-    async fetchMapDetails(playUri: string): Promise<MapDetailsData | RoomRedirect | ErrorApiData> {
+    async fetchMapDetails(
+        playUri: string,
+        userId?: string,
+        accessToken?: string
+    ): Promise<MapDetailsData | RoomRedirect | ErrorApiData> {
         if (!ADMIN_API_URL) {
             return Promise.reject(new Error("No admin backoffice set!"));
         }
 
-        const params: { playUri: string } = {
+        const params: { playUri: string; userId?: string; accessToken?: string } = {
             playUri,
         };
+
+        // Add user parameters if provided
+        if (userId) {
+            params.userId = userId;
+        }
+        if (accessToken) {
+            params.accessToken = accessToken;
+        }
 
         try {
             const res = await axios.get(ADMIN_API_URL + "/api/map", {

--- a/back/src/Services/SocketManager.ts
+++ b/back/src/Services/SocketManager.ts
@@ -894,7 +894,7 @@ export class SocketManager {
         let meetingId = joinBBBMeetingQuery.meetingId;
         const localMeetingId = joinBBBMeetingQuery.localMeetingId;
         const meetingName = joinBBBMeetingQuery.meetingName;
-        const bbbSettings = gameRoom.getBbbSettings();
+        const bbbSettings = await gameRoom.getBbbSettings(user);
 
         if (bbbSettings === undefined) {
             throw new Error(


### PR DESCRIPTION
Instead of fetching the BBB information only once and storing in the GameRoom, we now refetch it every time the user joins a rooms.

Currently, when starting WorkAdventure we see 4 calls to the `/api/map` admin API call, some with user information, some without. The GameRoom ended up being set up after a call to `/api/map` without the user information, so the API could not return custom BBB info. Now it fetches from` /api/map` again right before joining a conference, just to get the custom BigBlueButton room options, if they exist.

These are examples of the calls the admin API received before the change:

```
Started GET "/worka/admin/api/map?playUri=http:%2F%2Fplay.workadventure.localhost%2F%40%2Fworka%2F13-elos-imersivo%3FmatrixLoginToken%3Dsyl_ooooooCyjHsqPOmcgJjY_000000%26token%3Dey00000iOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudGlm00000joiZGFyb25jb0BtY29uZi5jb20iLCJhY2Nlc3NUb2tlbi000006RkdXVXlzY1EtT0RFTXNydnRmWkJGTkoyaDgycWlSV21oMVVBX2hxbXciLCJ1c2VybmFtZSI6Ikxlb25hcmRvIiwibWF0cml4VXNlcklkIjoiZGFyb25jb19tY29uZi5jb20iLCJpYXQiOjE3NTIwOTQ4MTIsImV4cCI6MTc1NDY400000n0.EhDNKi_9OnNd88WCxLR8qc00000hIEbFWpUN4UB6lXU" for 191.19.71.161 at 2025-07-09 21:00:12 +0000
Started GET "/worka/admin/api/map?playUri=http:%2F%2Fplay.workadventure.localhost%2F%40%2Fworka%2F13-elos-imersivo%3FmatrixLoginToken%3Dsyl_ooooooCyjHsqPOmcgJjY_000000" for 191.19.71.161 at 2025-07-09 21:00:21 +0000
Started GET "/worka/admin/api/map?playUri=http:%2F%2Fplay.workadventure.localhost%2F%40%2Fworka%2F13-elos-imersivo&userId=user%40mconf.com&accessToken=[FILTERED]" for 191.19.71.161 at 2025-07-09 21:00:22 +0000
Started GET "/worka/admin/api/map?playUri=http:%2F%2Fplay.workadventure.localhost%2F%40%2Fworka%2F13-elos-imersivo" for 191.19.71.161 at 2025-07-09 21:00:24 +0000
```

Now, when a user is joining a conference it will also make this call:

```
Started GET "/worka/admin/api/map?playUri=http:%2F%2Fplay.workadventure.localhost%2F%40%2Fworka%2F13-elos-imersivo&userId=000000002a3a36eab4d136788b8a1f3f8c8bf58403328115e0c1ec5800000000" for 191.19.71.161 at 2025-07-09 21:00:42 +0000
```