### PR TITLE
[PRT-2459] Prevent exposure of BBB data in the frontend

### DIFF
--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -20,8 +20,10 @@ class AdminApi {
             return Promise.reject(new Error("No admin backoffice set!"));
         }
 
-        const params: { playUri: string; userId?: string; accessToken?: string } = {
+        // the `fromBackend` parameter is used to identify the component making the request
+        const params: { playUri: string; userId?: string; accessToken?: string; fromBackend: boolean } = {
             playUri,
+            fromBackend: true,
         };
 
         // Add user parameters if provided

--- a/back/src/Services/AdminApi.ts
+++ b/back/src/Services/AdminApi.ts
@@ -20,10 +20,8 @@ class AdminApi {
             return Promise.reject(new Error("No admin backoffice set!"));
         }
 
-        // the `fromBackend` parameter is used to identify the component making the request
-        const params: { playUri: string; userId?: string; accessToken?: string; fromBackend: boolean } = {
+        const params: { playUri: string; userId?: string; accessToken?: string } = {
             playUri,
-            fromBackend: true,
         };
 
         // Add user parameters if provided

--- a/play/src/pusher/services/AdminApi.ts
+++ b/play/src/pusher/services/AdminApi.ts
@@ -291,6 +291,8 @@ class AdminApi implements AdminInterface {
             const mapDetailData = isMapDetailsData.safeParse(res.data);
 
             if (mapDetailData.success) {
+                // Remove BBB data, the secret should not be exposed to the frontend
+                mapDetailData!.data!.thirdParty!.bbb = null;
                 return mapDetailData.data;
             }
 


### PR DESCRIPTION
Remove BBB settings from the `fetchMapDetails` response from Pusher to Front, to avoid exposure of the BBB secret.