### PR TITLE
Add geolocation permission to BigBlueButton's iframe

### DIFF
--- a/play/src/front/WebRtc/BBBFactory.ts
+++ b/play/src/front/WebRtc/BBBFactory.ts
@@ -11,7 +11,7 @@ class BBBFactory {
         }
 
         const allowPolicy =
-            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *; fullscreen *";
+            "microphone *; camera *; display-capture *; clipboard-read *; clipboard-write *; screen-wake-lock *; fullscreen *; geolocation *";
         const coWebsite = new BBBCoWebsite(new URL(clientURL), false, allowPolicy, undefined, false);
         coWebsiteManager.addCoWebsiteToStore(coWebsite, 0);
         coWebsiteManager.loadCoWebsite(coWebsite).catch((e) => console.error(`Error on opening co-website: ${e}`));


### PR DESCRIPTION
Added `geolocation *` to the `allowPolicy` string for BigBlueButton iframes, enabling the request of geolocation permissions.